### PR TITLE
 * Extended the interface so that the control's name can be set

### DIFF
--- a/Xwt.WPF/Xwt.WPFBackend/WidgetBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/WidgetBackend.cs
@@ -178,6 +178,12 @@ namespace Xwt.WPFBackend
 			set { Widget.Opacity = value; }
 		}
 
+		public string Name
+		{
+			get { return Widget.Name; }
+			set { Widget.Name = value; }
+		}
+
 		FontData GetWidgetFont ()
 		{
 			if (!(Widget is Control)) {

--- a/Xwt/Xwt.Backends/IWidgetBackend.cs
+++ b/Xwt/Xwt.Backends/IWidgetBackend.cs
@@ -64,6 +64,11 @@ namespace Xwt.Backends
 		bool Sensitive { get; set; }
 
 		/// <summary>
+		/// Gets or sets the name of this widget.
+		/// </summary>
+		string Name { get; set; }
+
+		/// <summary>
 		/// Gets or sets a value indicating whether this widget can get focus.
 		/// </summary>
 		/// <value><c>true</c> if this instance can get focus; otherwise, <c>false</c>.</value>


### PR DESCRIPTION
- Implemented extended interface in WPF/WidgetBackend.

This change is important for UI automation/UI testing tools like Microsoft Test Manager. These tools use the name of a control to identify it, without setting a name, at least Microsoft Test Manager will use the first control of that type that it encounters (for example: the minimize button)
